### PR TITLE
Clean up the code and some initial maintaining tasks.

### DIFF
--- a/nece/admin.py
+++ b/nece/admin.py
@@ -12,17 +12,16 @@ def generate_translatable_schema(model):
     # noinspection PyProtectedMember
     translatable_fields = model._meta.translatable_fields
     return {
-        'type': 'object',
-        'properties': {
+        "type": "object",
+        "properties": {
             language: {
-                'type': 'object',
-                'properties': {
-                    field: {
-                        'type': 'string'
-                    } for field in translatable_fields
+                "type": "object",
+                "properties": {
+                    field: {"type": "string"} for field in translatable_fields
                 },
-            } for language in settings.TRANSLATIONS_MAP
-        }
+            }
+            for language in settings.TRANSLATIONS_MAP
+        },
     }
 
 
@@ -32,6 +31,10 @@ class TranslatableModelAdmin(ModelAdmin):
     """
 
     def formfield_for_dbfield(self, db_field, **kwargs):
-        if db_field.name == 'translations':
-            kwargs['widget'] = JSONEditorWidget(generate_translatable_schema(self.model), False)
-        return super(TranslatableModelAdmin, self).formfield_for_dbfield(db_field, **kwargs)
+        if db_field.name == "translations":
+            kwargs["widget"] = JSONEditorWidget(
+                generate_translatable_schema(self.model), False
+            )
+        return super(TranslatableModelAdmin, self).formfield_for_dbfield(
+            db_field, **kwargs
+        )

--- a/nece/exceptions.py
+++ b/nece/exceptions.py
@@ -1,5 +1,5 @@
 class NonTranslatableFieldError(Exception):
     def __init__(self, fieldname):
         self.fieldname = fieldname
-        message = "{} is not in translatable fields".format(fieldname)
+        message = f"{fieldname} is not in translatable fields"
         super(NonTranslatableFieldError, self).__init__(message)

--- a/nece/managers.py
+++ b/nece/managers.py
@@ -47,7 +47,7 @@ class TranslationMixin(object):
 
 class TranslationModelIterable(ModelIterable):
     def __iter__(self):
-        for obj in super(TranslationModelIterable, self).__iter__():
+        for obj in super().__iter__():
             if self.queryset._language_code:
                 # Set the current language without fallback
                 # as query does not support fallback
@@ -59,7 +59,7 @@ class TranslationQuerySet(models.QuerySet, TranslationMixin):
     _language_code = None
 
     def __init__(self, model=None, query=None, using=None, hints=None):
-        super(TranslationQuerySet, self).__init__(model, query, using, hints)
+        super().__init__(model, query, using, hints)
         self._iterable_class = TranslationModelIterable
 
     def language_or_default(self, language_code):

--- a/nece/models.py
+++ b/nece/models.py
@@ -1,19 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-try:
-    from django.db.models import JSONField
-except ImportError:
-    # Django < 3.1
-    from django.contrib.postgres.fields import JSONField
 from django.db import models
-from django.db.models import options
+from django.db.models import JSONField, options
 
-from nece.managers import TranslationManager, TranslationMixin
 from nece.exceptions import NonTranslatableFieldError
+from nece.managers import TranslationManager, TranslationMixin
 
-
-options.DEFAULT_NAMES += ('translatable_fields',)
+options.DEFAULT_NAMES += ("translatable_fields",)
 
 
 class Language(object):
@@ -35,9 +29,9 @@ class TranslationModel(models.Model, TranslationMixin):
 
     def __getattribute__(self, name):
         attr = object.__getattribute__(self, name)
-        if name.startswith('__'):
+        if name.startswith("__"):
             return attr
-        translated = object.__getattribute__(self, '_translated')
+        translated = object.__getattribute__(self, "_translated")
         if translated:
             if hasattr(translated, name):
                 return getattr(translated, name) or attr
@@ -83,8 +77,7 @@ class TranslationModel(models.Model, TranslationMixin):
         language_codes = self.get_language_keys(language_code, fallback)
         # Default language field
         fields = self._meta.translatable_fields
-        self.default_language = Language(
-            **{i: getattr(self, i, None) for i in fields})
+        self.default_language = Language(**{i: getattr(self, i, None) for i in fields})
         # Translation fields
         if self.translations:
             for code in language_codes:
@@ -124,7 +117,7 @@ class TranslationModel(models.Model, TranslationMixin):
     def save(self, *args, **kwargs):
         language_code = self._language_code
         self.reset_language()
-        if self.translations == '':
+        if self.translations == "":
             self.translations = None
         super(TranslationModel, self).save(*args, **kwargs)
         self.language(language_code)

--- a/nece/models.py
+++ b/nece/models.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import models
 from django.db.models import JSONField, options
 

--- a/nece/tests.py
+++ b/nece/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+coverage
+coveralls
+dj-database-url
+psycopg2

--- a/runtests.py
+++ b/runtests.py
@@ -4,13 +4,13 @@ import sys
 import django
 
 if __name__ == "__main__":
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.test_settings'
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.test_settings"
 
     from django.conf import settings
     from django.test.utils import get_runner
 
     django.setup()
-    os.chdir('tests')
+    os.chdir("tests")
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
     failures = test_runner.run_tests(["tests"])

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,3 @@
 from setuptools import setup
+
 setup()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 import itertools
 
 from .models import Fruit
@@ -8,29 +8,15 @@ def get_fixtures(n=None):
     fixtures = [
         {
             "translations": {
-                "de_de": {
-                    "benefits": "gut für die Feuerstelle",
-                    "name": "Apfel"
-                },
-                "fr_fr": {
-                    "benefits": "bon pour la santé",
-                    "name": "pomme"
-                },
-                "ku_tr": {
-                    "name": "sêv"
-                },
-                "tr_tr": {
-                    "benefits": "Kalbe yararlıdır",
-                    "name": "elma"
-                },
-                "en_us": {
-                    "benefits": "there are benefits",
-                    "name": "new york"
-                },
+                "de_de": {"benefits": "gut für die Feuerstelle", "name": "Apfel"},
+                "fr_fr": {"benefits": "bon pour la santé", "name": "pomme"},
+                "ku_tr": {"name": "sêv"},
+                "tr_tr": {"benefits": "Kalbe yararlıdır", "name": "elma"},
+                "en_us": {"benefits": "there are benefits", "name": "new york"},
             },
             "name": "apple",
             "benefits": "good for health",
-            "scientific_name": "malus domestica"
+            "scientific_name": "malus domestica",
         },
         {
             "translations": {
@@ -38,27 +24,26 @@ def get_fixtures(n=None):
                     "benefits": "Päärynät tarjoavat erittäin hyvä kuidun"
                     "lähde, ja ne ovat myös hyvä lähde B2-vitamiinia, "
                     "C, E, kupari, ja kalium.",
-                    "name": "päärynät"
+                    "name": "päärynät",
                 },
                 "tr_tr": {
                     "benefits": "Armut lif çok iyi bir kaynağı sağlar ve "
                     "aynı zamanda vitamin B2, C, E, bakır ve potasyum "
                     "için iyi bir kaynaktır.",
-                    "name": "armut"
-                }
+                    "name": "armut",
+                },
             },
             "name": "pear",
             "benefits": "Pears provide a very good source of fiber and "
             "are also a good source of vitamin B2, C, E, copper, "
             "and potassium.",
-            "scientific_name": "Pyrus"
+            "scientific_name": "Pyrus",
         },
         {
             "name": "banana",
             "benefits": "Potassium",
-            "scientific_name": "Musa acuminata"
+            "scientific_name": "Musa acuminata",
         },
-
     ]
     n = n or len(fixtures)
     fixtures = itertools.cycle(fixtures)

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,7 +10,10 @@ class Fruit(TranslationModel):
     scientific_name = models.CharField(max_length=255)
 
     class Meta:
-        translatable_fields = ('name', 'benefits', )
+        translatable_fields = (
+            "name",
+            "benefits",
+        )
 
     def __str__(self):
         return self.name

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,18 +3,21 @@ import dj_database_url
 
 BASE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), os.pardir)
 
-SECRET_KEY = 'not_so_secret_r2fetCebUAZB3DhzTn5NPg8J08IancuGt04npTMh'
+SECRET_KEY = "not_so_secret_r2fetCebUAZB3DhzTn5NPg8J08IancuGt04npTMh"
 DEBUG = True
 
-db_url = os.environ.get("DATABASE_URL",
-                        "postgres://postgres@127.0.0.1/django_nece_test")
+db_url = os.environ.get(
+    "DATABASE_URL", "postgres://postgres@127.0.0.1/django_nece_test"
+)
 DB = dj_database_url.parse(db_url)
 
-DATABASES = {
-    'default': DB
-}
+DATABASES = {"default": DB}
+DEFAULT_AUTO_FIELD='django.db.models.AutoField'
 
-INSTALLED_APPS = ('nece', 'tests',)
-TRANSLATIONS_DEFAULT = 'en_us'
-TRANSLATIONS_MAP = {'en': 'en_us', 'tr': 'tr_tr', 'de': 'de_de', 'it': 'it_it'}
-TRANSLATIONS_FALLBACK = {'fr_ca': ['fr_fr'], 'en_us': ['en_gb']}
+INSTALLED_APPS = (
+    "nece",
+    "tests",
+)
+TRANSLATIONS_DEFAULT = "en_us"
+TRANSLATIONS_MAP = {"en": "en_us", "tr": "tr_tr", "de": "de_de", "it": "it_it"}
+TRANSLATIONS_FALLBACK = {"fr_ca": ["fr_fr"], "en_us": ["en_gb"]}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,11 +18,10 @@ class MixinObject(managers.TranslationMixin):
 
 
 class TranslationMixinTest(TestCase):
-
     def test_get_language_keys(self):
         obj = MixinObject()
-        self.assertEqual(['en_us', 'en_gb'], obj.get_language_keys('en_us'))
-        self.assertEqual(['en_us', 'en_gb'], obj.get_language_keys('en'))
+        self.assertEqual(["en_us", "en_gb"], obj.get_language_keys("en_us"))
+        self.assertEqual(["en_us", "en_gb"], obj.get_language_keys("en"))
 
 
 class TranslationTest(TestCase):
@@ -32,88 +31,100 @@ class TranslationTest(TestCase):
 
     def test_basic_queries(self):
         Fruit.objects.all()
-        Fruit.objects.filter(name='apple')
+        Fruit.objects.filter(name="apple")
         Fruit.objects.values()
         Fruit.objects.values_list()
-        Fruit.objects.earliest('pk')
-        Fruit.objects.latest('pk')
+        Fruit.objects.earliest("pk")
+        Fruit.objects.latest("pk")
+
+    def test_language_filter_queryset_with_contains(self):
+        fruits = Fruit.objects.language("de_de").filter(name__contains="pfel")
+        self.assertEqual(fruits.count(), 1)
 
     def test_language_filter(self):
-        self.assertEqual(Fruit.objects.language('en_us').get(
-            name='apple').name, 'apple')
-        self.assertEqual(Fruit.objects.language('de_de').get(
-            name="Apfel").name, 'Apfel')
+        self.assertEqual(
+            Fruit.objects.language("en_us").get(name="apple").name, "apple"
+        )
+        self.assertEqual(
+            Fruit.objects.language("de_de").get(name="Apfel").name, "Apfel"
+        )
 
     def test_language_or_default(self):
-        fruits = Fruit.objects.language_or_default('tr_tr')
+        fruits = Fruit.objects.language_or_default("tr_tr")
         self.assertEqual(fruits.count(), 3)
 
     def test_language_or_none(self):
-        fruit = Fruit.objects.get(name='apple')
-        self.assertEqual(fruit.language_or_none('en').name, 'apple')
-        self.assertEqual(fruit.language_or_none('tr').name, 'elma')
-        self.assertEqual(fruit.language_or_none('gibrish'), None)
+        fruit = Fruit.objects.get(name="apple")
+        self.assertEqual(fruit.language_or_none("en").name, "apple")
+        self.assertEqual(fruit.language_or_none("tr").name, "elma")
+        self.assertEqual(fruit.language_or_none("gibrish"), None)
 
     def test_language_switch(self):
-        fruit = Fruit.objects.get(name='apple')
-        self.assertEqual(fruit.name, 'apple')
-        fruit.language('tr_tr')
-        self.assertEqual(fruit.name, 'elma')
-        self.assertEqual(fruit.default_language.name, 'apple')
-        fruit.language('de_de')
-        self.assertEqual(fruit.name, 'Apfel')
-        self.assertEqual(fruit.default_language.name, 'apple')
-        fruit.language('fr_fr')
-        self.assertEqual(fruit.name, 'pomme')
-        self.assertEqual(fruit.default_language.name, 'apple')
-        fruit.language('fr_ca')
-        self.assertEqual(fruit.name, 'pomme')
-        self.assertEqual(fruit.default_language.name, 'apple')
-        fruit.language('fr_ca', fallback=False)
-        self.assertEqual(fruit.name, 'apple')
-        self.assertEqual(fruit.default_language.name, 'apple')
+        fruit = Fruit.objects.get(name="apple")
+        self.assertEqual(fruit.name, "apple")
+        fruit.language("tr_tr")
+        self.assertEqual(fruit.name, "elma")
+        self.assertEqual(fruit.default_language.name, "apple")
+        fruit.language("de_de")
+        self.assertEqual(fruit.name, "Apfel")
+        self.assertEqual(fruit.default_language.name, "apple")
+        fruit.language("fr_fr")
+        self.assertEqual(fruit.name, "pomme")
+        self.assertEqual(fruit.default_language.name, "apple")
+        fruit.language("fr_ca")
+        self.assertEqual(fruit.name, "pomme")
+        self.assertEqual(fruit.default_language.name, "apple")
+        fruit.language("fr_ca", fallback=False)
+        self.assertEqual(fruit.name, "apple")
+        self.assertEqual(fruit.default_language.name, "apple")
 
     def test_save_correct_languages(self):
-        fruit = Fruit.objects.get(name='apple')
-        fruit.translate(name='not apple')
-        fruit.language('tr_tr')
-        fruit.translate(name='elma değil')
-        self.assertEqual(fruit.translations['tr_tr']['name'], 'elma değil')
-        fruit.language('de_de')
-        fruit.translate(name='nicht Apfel')
-        self.assertEqual(fruit.translations['de_de']['name'], 'nicht Apfel')
-        self.assertEqual(fruit.default_language.name, 'not apple')
+        fruit = Fruit.objects.get(name="apple")
+        fruit.translate(name="not apple")
+        fruit.language("tr_tr")
+        fruit.translate(name="elma değil")
+        self.assertEqual(fruit.translations["tr_tr"]["name"], "elma değil")
+        fruit.language("de_de")
+        fruit.translate(name="nicht Apfel")
+        self.assertEqual(fruit.translations["de_de"]["name"], "nicht Apfel")
+        self.assertEqual(fruit.default_language.name, "not apple")
         fruit.save()
 
     def test_get_by_language(self):
-        self.assertEqual(
-            Fruit.objects.language('tr_tr').get(name='elma').name, 'elma')
+        self.assertEqual(Fruit.objects.language("tr_tr").get(name="elma").name, "elma")
 
     def test_nontranslatable_fields(self):
-        fruit = Fruit.objects.get(name='apple')
+        fruit = Fruit.objects.get(name="apple")
         with self.assertRaises(NonTranslatableFieldError) as error:
-            fruit.translate('it_it', dummy_field='hello')
-        self.assertEqual(error.exception.fieldname, 'dummy_field')
+            fruit.translate("it_it", dummy_field="hello")
+        self.assertEqual(error.exception.fieldname, "dummy_field")
 
     def test_translation_mapping(self):
-        self.assertTrue(Fruit.objects.language('tr').exists())
-        self.assertEqual(Fruit.objects.language('tr')[0].name, 'elma')
+        self.assertTrue(Fruit.objects.language("tr").exists())
+        self.assertEqual(Fruit.objects.language("tr")[0].name, "elma")
 
     def test_language_as_dict(self):
-        fruit = Fruit.objects.get(name='apple')
-        self.assertEqual(fruit.language_as_dict(),  # default lang
-                         {'benefits': u'good for health', 'name': u'apple'})
-        self.assertEqual(fruit.language_as_dict('en_us'),
-                         {'benefits': u'good for health', 'name': u'apple'})
-        fruit.translate('az_az', name='alma')
-        self.assertEqual(fruit.language_as_dict('az_az'),
-                         {'name': 'alma'})
-        self.assertEqual(fruit.language_as_dict('non_existant', fallback=False), {})
-        self.assertEqual(fruit.language_as_dict('fr_fr'),
-                         {'name': 'pomme', 'benefits': 'bon pour la santé'})
-        self.assertEqual(fruit.language_as_dict('fr_ca'),
-                         {'name': 'pomme', 'benefits': 'bon pour la santé'})
-        self.assertEqual(fruit.language_as_dict('fr_ca', fallback=False), {})
+        fruit = Fruit.objects.get(name="apple")
+        self.assertEqual(
+            fruit.language_as_dict(),  # default lang
+            {"benefits": "good for health", "name": "apple"},
+        )
+        self.assertEqual(
+            fruit.language_as_dict("en_us"),
+            {"benefits": "good for health", "name": "apple"},
+        )
+        fruit.translate("az_az", name="alma")
+        self.assertEqual(fruit.language_as_dict("az_az"), {"name": "alma"})
+        self.assertEqual(fruit.language_as_dict("non_existant", fallback=False), {})
+        self.assertEqual(
+            fruit.language_as_dict("fr_fr"),
+            {"name": "pomme", "benefits": "bon pour la santé"},
+        )
+        self.assertEqual(
+            fruit.language_as_dict("fr_ca"),
+            {"name": "pomme", "benefits": "bon pour la santé"},
+        )
+        self.assertEqual(fruit.language_as_dict("fr_ca", fallback=False), {})
 
     def test_values(self):
         names = Fruit.objects.values()
@@ -125,94 +136,96 @@ class TranslationOrderingTest(TestCase):
     def setUp(self):
         super(TranslationOrderingTest, self).setUp()
         CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
-        call_command('loaddata', '%s/ordering.json' % CURRENT_DIR)
+        call_command("loaddata", "%s/ordering.json" % CURRENT_DIR)
 
     def test_order_by_name_asc(self):
         # en_us
         expected_order = [
-            'Apple',
-            'Banana',
-            'Grapefruit',
-            'Lemon',
-            'Orange',
-            'Pear',
-            'Strawberry',
+            "Apple",
+            "Banana",
+            "Grapefruit",
+            "Lemon",
+            "Orange",
+            "Pear",
+            "Strawberry",
         ]
-        fruits = Fruit.objects.language('en_us').order_by_json_path('name')
+        fruits = Fruit.objects.language("en_us").order_by_json_path("name")
         for i, fruit in enumerate(fruits):
             self.assertEqual(fruit.name, expected_order[i])
 
         # fr_fr
         expected_order = [
-            'Banane',
-            'Citron',
-            'Fraise',
-            'Orange',
-            'Pamplemousse',
-            'Poire',
-            'Pomme',
+            "Banane",
+            "Citron",
+            "Fraise",
+            "Orange",
+            "Pamplemousse",
+            "Poire",
+            "Pomme",
         ]
-        fruits = Fruit.objects.language('fr_fr').order_by_json_path('name')
+        fruits = Fruit.objects.language("fr_fr").order_by_json_path("name")
         for i, fruit in enumerate(fruits):
             self.assertEqual(fruit.name, expected_order[i])
 
         # tr_tr
         expected_order = [
-            'Armut',
-            'Çilek',
-            'Elma',
-            'Greyfurt',
-            'Limon',
-            'Muz',
-            'Portakal',
+            "Armut",
+            "Çilek",
+            "Elma",
+            "Greyfurt",
+            "Limon",
+            "Muz",
+            "Portakal",
         ]
-        fruits = Fruit.objects.language('tr_tr').order_by_json_path('name')
+        fruits = Fruit.objects.language("tr_tr").order_by_json_path("name")
         for i, fruit in enumerate(fruits):
             self.assertEqual(fruit.name, expected_order[i])
 
     def test_order_by_name_desc(self):
         # en_us
         expected_order = [
-            'Strawberry',
-            'Pear',
-            'Orange',
-            'Lemon',
-            'Grapefruit',
-            'Banana',
-            'Apple',
+            "Strawberry",
+            "Pear",
+            "Orange",
+            "Lemon",
+            "Grapefruit",
+            "Banana",
+            "Apple",
         ]
         fruits = Fruit.objects.order_by_json_path(
-            'name', language_code='en_us', order='desc')
+            "name", language_code="en_us", order="desc"
+        )
         for i, fruit in enumerate(fruits):
             self.assertEqual(fruit.name, expected_order[i])
 
         # fr_fr
         expected_order = [
-            'Pomme',
-            'Poire',
-            'Pamplemousse',
-            'Orange',
-            'Fraise',
-            'Citron',
-            'Banane',
+            "Pomme",
+            "Poire",
+            "Pamplemousse",
+            "Orange",
+            "Fraise",
+            "Citron",
+            "Banane",
         ]
         fruits = Fruit.objects.order_by_json_path(
-            'name', language_code='fr_fr', order='desc')
+            "name", language_code="fr_fr", order="desc"
+        )
         for i, fruit in enumerate(fruits):
             self.assertEqual(fruit.name, expected_order[i])
 
         # tr_tr
         expected_order = [
-            'Portakal',
-            'Muz',
-            'Limon',
-            'Greyfurt',
-            'Elma',
-            'Çilek',
-            'Armut',
+            "Portakal",
+            "Muz",
+            "Limon",
+            "Greyfurt",
+            "Elma",
+            "Çilek",
+            "Armut",
         ]
         fruits = Fruit.objects.order_by_json_path(
-            'name', language_code='tr_tr', order='desc')
+            "name", language_code="tr_tr", order="desc"
+        )
         for i, fruit in enumerate(fruits):
             self.assertEqual(fruit.name, expected_order[i])
-

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,7 +26,6 @@ class TranslationMixinTest(TestCase):
 
 class TranslationTest(TestCase):
     def setUp(self):
-        super(TranslationTest, self).setUp()
         create_fixtures()
 
     def test_basic_queries(self):

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,13 @@ envlist = {py39,py310}-django{4.0,4.1}
 
 [testenv]
 commands =
-    coverage run --source nece runtests.py --fast --create-db
+    coverage run --append --source nece runtests.py --fast --create-db
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
     -r{toxinidir}/requirements-test.txt
-    django40: Django==4.0.5
-    django41: Django==4.1.a1
+    django4.0: Django==4.0.5
+    django4.1: Django==4.1.a1
 
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals = sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+downloadcache = {toxworkdir}/_download/
+envlist = {py39,py310}-django{4.0,4.1}
+
+[testenv]
+commands =
+    coverage run --source nece runtests.py --fast --create-db
+setenv =
+       PYTHONDONTWRITEBYTECODE=1
+deps =
+    -r{toxinidir}/requirements-test.txt
+    django40: Django==4.0.5
+    django41: Django==4.1.a1
+
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+whitelist_externals = sh
+
+[travis:env]
+DJANGO =
+    4.0: django4.0
+    4.1: django4.1


### PR DESCRIPTION
Also added tests for versions of Django 4.0 and 4.1, and versions of python 3.9 and 3.10

The idea is to eventually have something like Travis CI (as it was on the original repo) running the tests and be able to tests different versions of python and Django so far I've added the one I'm interested that the project will run.

Also reformatted code with black, standardized strings into fstrings and remove warnings, etc.

List of things done so far in this PR:

- Use fstrings instead of mixture of interpolation + format, etc.
- Remove warning in settings
- Run black on the project
- Remove old TODO
- Remove unnecesary lines on tests.py file
- Sort imports
- Add a workaround for `TranslationQuerySet.filter` when it's used with `contains` and added a test case